### PR TITLE
update virtual-jade to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "babylon": "^6.8.1",
-    "virtual-jade": "^0.3.2"
+    "virtual-jade": ">=0.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
(and loosen dependency restriction to >= so that minor version bumps to `virtual-jade` don't break `mixpanel-common` installs)
