### PR TITLE
pass plugin options to virtual-jade compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,15 @@
   "author": "wymetyme@gmail.com",
   "license": "MIT",
   "dependencies": {
-    "babylon": "^6.8.1",
-    "virtual-jade": ">=0.5.0"
+    "babylon": "^6.8.1"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "eslint": "^2.11.1",
     "eslint-plugin-sorting": "^0.1.0"
+  },
+  "peerDependencies": {
+    "virtual-jade": ">=0.8.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const fileExists = filename => {
   }
 };
 
-const compileVirtualJadeFile = (jsFile, jadeFile) => {
+const compileVirtualJadeFile = (jsFile, jadeFile, options={}) => {
   // try to resolve as file path
   const from = resolveModulePath(jsFile);
   let path = resolve(from, jadeFile);
@@ -30,9 +30,9 @@ const compileVirtualJadeFile = (jsFile, jadeFile) => {
   }
 
   const jadeContent = fs.readFileSync(path, 'utf8');
-  return vjade(jadeContent, {
+  return vjade(jadeContent, Object.assign({
     filename: path,
-  });
+  }, options));
 };
 
 const resolveModulePath = (filename) => {
@@ -50,7 +50,7 @@ export default () => {
         if (node && node.source && node.source.value && node.source.type === 'StringLiteral' && node.source.value.endsWith('.jade')) {
           const jsFile = state.file.opts.filename;
           const jadeFile = node.source.value;
-          const jadeFnStr = compileVirtualJadeFile(jsFile, jadeFile);
+          const jadeFnStr = compileVirtualJadeFile(jsFile, jadeFile, state.opts);
           const varName = node.specifiers[0].local.name;
           const srcString = `var ${varName} = ${jadeFnStr}`;
           path.replaceWith(babylon.parse(srcString));


### PR DESCRIPTION
so you can do stuff like
```json
{
  "plugins": [
    ["babel-plugin-virtual-jade", {
      "vdom": "snabbdom"
    }]
  ]
}
```